### PR TITLE
[FEAT] 약속 신청 뷰 세부 수정사항 기능 구현완료

### DIFF
--- a/SeeMeet/SeeMeet/Source/Models/FriendsScene/FriendsListDataModel.swift
+++ b/SeeMeet/SeeMeet/Source/Models/FriendsScene/FriendsListDataModel.swift
@@ -12,4 +12,43 @@ struct FriendsDataModel: Codable {
 struct FriendsData: Codable {
     let id: Int
     let username, email: String
+    
+   init(id: Int, username: String, email: String){
+        self.id = id
+        self.username = username
+        self.email = email
+    }
+    init(){//Codable 초기화.. 이거 마자..?흠,,,,이렇게하니까 from:Decoder 채우라는 오류는 안나옴
+        self.id = 0
+        self.username = ""
+        self.email = ""
+    }
+    
 }
+
+extension FriendsData: Equatable {
+    static func == (lhs: FriendsData, rhs: FriendsData) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+extension FriendsData: Comparable {//Comparable 이게 최선은 아닐듯 ..
+    static func < (lhs: FriendsData, rhs: FriendsData) -> Bool {
+        return lhs.username<lhs.username
+    }
+    
+    static func <= (lhs: FriendsData, rhs: FriendsData) -> Bool {
+        return lhs.username<=lhs.username
+    }
+    
+    static func > (lhs: FriendsData, rhs: FriendsData) -> Bool {
+        return lhs.username>lhs.username
+    }
+    
+    static func >= (lhs: FriendsData, rhs: FriendsData) -> Bool {
+        return lhs.username>=lhs.username
+    }
+    
+    
+}
+

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/ChipView.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/ChipView.swift
@@ -15,10 +15,10 @@ protocol TapRemoveButtonDelegate{
 
 class ChipView: UIView {
     
-    var name: String = ""
+    var friendsData = FriendsData()
     var tapRemoveButtonDelegate: TapRemoveButtonDelegate?
     
-    private let searchedLabel = UILabel().then{
+    private let nameLabel = UILabel().then{
         $0.font = UIFont.hanSansMediumFont(ofSize: 14)
         $0.textColor = UIColor.white
     }
@@ -44,12 +44,12 @@ class ChipView: UIView {
         private func configUI() {
             backgroundColor = UIColor.pink01
             layer.cornerRadius = 13
-            searchedLabel.text = name
+            nameLabel.text = self.friendsData.username
         
         }
         
         private func setLayout() {
-            addSubviews([searchedLabel,removeButton])
+            addSubviews([nameLabel,removeButton])
             
             
             self.snp.makeConstraints({
@@ -62,15 +62,15 @@ class ChipView: UIView {
                 $0.centerY.equalToSuperview()
             }
             
-            searchedLabel.snp.makeConstraints{
+            nameLabel.snp.makeConstraints{
                 $0.leading.equalToSuperview().offset(13)
                 $0.centerY.equalToSuperview()
             }
            
         }
-    func setName(name: String){
-        self.name = name
-        searchedLabel.text = name
+    func setFriendsData(friendsData: FriendsData){
+        self.friendsData = friendsData
+        self.nameLabel.text = friendsData.username
     }
     
     func setGestureRecognizer(){

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
@@ -123,6 +123,11 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
         self.searchTextField.addTarget(self, action: #selector(self.textFieldDidChange(_:)), for: .editingChanged)
     }
     
+//MARK: Override
+    //입력하다가 다른 곳 터치시 키패드 내려가게 하기
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
 //MARK: Function
     
     func dismissKeyboard() {

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
@@ -18,7 +18,7 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
         $0.font = UIFont.hanSansBoldFont(ofSize: 18)
     }
     private let closeButton = UIButton().then{
-        $0.setBackgroundImage(UIImage(named: "btn_close"), for: .normal)
+        $0.setBackgroundImage(UIImage(named: "btn_close_bold"), for: .normal)
         $0.addTarget(self, action: #selector(touchUpCloseButton(_:)), for: .touchUpInside)
     }
     private let friendSelectionLabel = UILabel().then{

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
@@ -75,6 +75,7 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
         $0.font = UIFont.hanSansBoldFont(ofSize: 14)
         $0.textColor = UIColor.grey06
         $0.attributedPlaceholder = NSAttributedString(string: "제목", attributes: [.foregroundColor: UIColor.grey04, .font: UIFont.hanSansRegularFont(ofSize: 14)])
+        $0.addTarget(self, action: #selector(switchNextButtonStatus), for: .editingChanged)
     }
     
     private let seperateLineView = UIView().then{
@@ -104,13 +105,17 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
 //MARK: Var
     var userWidth: CGFloat = UIScreen.getDeviceWidth()
     var userHeight: CGFloat = UIScreen.getDeviceHeight()
-    var nameList: [String] = []
-    var filterNameList = [String]()
+ 
+   
+    //   var nameList: [String] = []
+    var friendDataList: [FriendsData] = []
     
-    var friendData: [FriendsData] = []
-    var searchedFriendList: [FriendsData] = []
+    // var filterNameList = [String]()
+    var filterdFriendList: [FriendsData] = []
+    //var searchedNameList = [String]()
+    var selectedFriendList: [FriendsData] = []
     
-    var searchedNameList = [String]()
+   
     
 //MARK: ViewDidLoad
     override func viewDidLoad() {
@@ -146,9 +151,14 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
         
         nextVC.titleToRequest = plansTitleTextField.text ?? ""
         nextVC.contentsToRequest = plansContentsTextView.text ?? ""
-        nextVC.guestsToRequest = searchedFriendList.map { ["id": $0.id, "username": $0.username] }
+        nextVC.guestsToRequest = selectedFriendList.map { ["id": $0.id, "username": $0.username] }
         
         self.navigationController?.pushViewController(nextVC, animated: true)
+    }
+    
+    @objc func switchNextButtonStatus(){
+      //  if searchedNameList
+        
     }
     func setChipView(){
         searchTextField.placeholder = nil//셀추가시 플레이스 홀더 업애기
@@ -169,7 +179,7 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
             $0.leading.equalTo(chipView2.snp.trailing).offset(11)
             $0.top.equalToSuperview().offset(11)
         }
-        switch searchedNameList.count{
+        switch selectedFriendList.count{
         case 0:
             chipView1.isHidden = true
             chipView2.isHidden = true
@@ -179,22 +189,22 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
             chipView1.isHidden = false
             chipView2.isHidden = true
             chipView3.isHidden = true
-            chipView1.setName(name: searchedNameList[0])
+            chipView1.setFriendsData(friendsData: selectedFriendList[0])
             searchTextField.setLeftPadding(width: 46+2+93-5)
         case 2:
             chipView1.isHidden = false
             chipView2.isHidden = false
             chipView3.isHidden = true
-            chipView1.setName(name: searchedNameList[0])
-            chipView2.setName(name: searchedNameList[1])
+            chipView1.setFriendsData(friendsData: selectedFriendList[0])
+            chipView2.setFriendsData(friendsData: selectedFriendList[1])
             searchTextField.setLeftPadding(width: 46+2+93+93-5)
         case 3:
             chipView1.isHidden = false
             chipView2.isHidden = false
             chipView3.isHidden = false
-            chipView1.setName(name: searchedNameList[0])
-            chipView2.setName(name: searchedNameList[1])
-            chipView3.setName(name: searchedNameList[2])
+            chipView1.setFriendsData(friendsData: selectedFriendList[0])
+            chipView2.setFriendsData(friendsData: selectedFriendList[1])
+            chipView3.setFriendsData(friendsData: selectedFriendList[2])
             searchTextField.setLeftPadding(width: 46+2+93+93+93+100-5)
         default:
             chipView1.isHidden = false
@@ -209,8 +219,7 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
                    {
                    case .success(let data) :
                        if let response = data as? FriendsDataModel{
-                           self.nameList = response.data.map { $0.username }
-                           self.friendData = response.data
+                           self.friendDataList = response.data
                        }
                    case .requestErr(let message) :
                        print("requestERR")
@@ -374,7 +383,7 @@ extension RequestPlansContentsVC: UITextFieldDelegate{
             textField.layer.borderWidth = 1.0
             whiteView.isHidden = false
             searchTableView.isHidden = false
-            filterNameList = nameList
+            filterdFriendList = friendDataList
             searchTableView.reloadData()
         case plansTitleTextField:
             plansContentsView.layer.borderColor = UIColor.pink01.cgColor
@@ -400,13 +409,13 @@ extension RequestPlansContentsVC: UITextFieldDelegate{
     
     @objc func textFieldDidChange(_ sender: Any?) {
         if searchTextField.text == ""{
-            filterNameList = nameList
+            filterdFriendList = friendDataList
             searchTableView.reloadData()
             
         }else {
             whiteView.isHidden = false
             searchTableView.isHidden = false
-            filterNameList = nameList.filter { $0.lowercased().prefix(searchTextField.text!.count) == searchTextField.text!.lowercased() }
+            filterdFriendList = friendDataList.filter { $0.username.lowercased().prefix(searchTextField.text!.count) == searchTextField.text!.lowercased() }
             searchTableView.reloadData()
         }
     }
@@ -435,12 +444,12 @@ extension RequestPlansContentsVC: UITextFieldDelegate{
 
 extension RequestPlansContentsVC: UITableViewDataSource{
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        filterNameList.count
+        filterdFriendList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SearchTVC.identifier,for: indexPath) as? SearchTVC else {return UITableViewCell()}
-        cell.setData(name: filterNameList[indexPath.row])
+        cell.setData(name: filterdFriendList[indexPath.row].username)
         return cell
     }
 }
@@ -452,13 +461,13 @@ extension RequestPlansContentsVC: UITableViewDelegate{
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         searchTextField.text = ""//이름 선택하면 텍스트 필드 비우기
-        if(searchedNameList.count<3){ //이름 세개까지만 추가
-            searchedNameList.append(filterNameList[indexPath.row])
-            guard let name = friendData.filter { $0.username == filterNameList[indexPath.row] }.first else { return }
-            searchedFriendList.append(name)
-            nameList = nameList.filter { !searchedNameList.contains($0) }
+        if(selectedFriendList.count<3){ //이름 세개까지만 추가
+            selectedFriendList.append(filterdFriendList[indexPath.row])
+//            guard let name = friendDataList.filter { $0.username == filterdFriendList[indexPath.row].username }.first else { return }
+//            selectedFriendList.append(name)
+            friendDataList = friendDataList.filter { !selectedFriendList.contains($0) }
             setChipView()
-            print(searchedNameList)
+          
         }
         tableView.isHidden = true
         searchTextField.endEditing(true)
@@ -469,16 +478,15 @@ extension RequestPlansContentsVC: TapRemoveButtonDelegate{
     
     func tapRemoveButton(chipView: ChipView) {
        
-        let name: String
-        name = chipView.name
-        if let idx = searchedNameList.firstIndex(of: name){
-            searchedNameList.remove(at: idx)
-            searchedFriendList.remove(at: idx)
+        
+        let removeFriend = chipView.friendsData
+        if let idx = selectedFriendList.firstIndex(of: removeFriend){
+            selectedFriendList.remove(at: idx)
         }
         
         setChipView()
-        nameList.append(chipView.name)
-        nameList.sort()
+        friendDataList.append(removeFriend)
+        friendDataList.sort()
         searchTableView.reloadData()
     }
 }

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansContentsVC.swift
@@ -96,7 +96,8 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
     }
     
     private let nextButton = UIButton().then{
-        $0.backgroundColor = UIColor.pink01
+        $0.backgroundColor = UIColor.grey02
+        $0.isUserInteractionEnabled = false
         $0.setTitle("다음", for: .normal)
         $0.titleLabel?.font = UIFont.hanSansMediumFont(ofSize: 16)
         $0.layer.cornerRadius = 10
@@ -113,7 +114,13 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
     // var filterNameList = [String]()
     var filterdFriendList: [FriendsData] = []
     //var searchedNameList = [String]()
-    var selectedFriendList: [FriendsData] = []
+    var selectedFriendList: [FriendsData] = []{
+        didSet{
+            switchNextButtonStatus()//선택한 친구목록 바뀔 때마다 다음 버튼 활성화할지 판단
+        }
+    }
+    
+    let textViewPlaceHolderConstant = "약속 상세 내용"
     
    
     
@@ -157,7 +164,14 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
     }
     
     @objc func switchNextButtonStatus(){
-      //  if searchedNameList
+        //선택된 친구가 있고 약속제목과 내용이 있을 때
+        if selectedFriendList.count != 0 && plansTitleTextField.hasText && plansContentsTextView.hasText && plansContentsTextView.text != textViewPlaceHolderConstant{
+            nextButton.backgroundColor = UIColor.pink01
+            nextButton.isUserInteractionEnabled  = true
+        }else{
+            nextButton.backgroundColor = UIColor.grey02
+            nextButton.isUserInteractionEnabled  = false
+        }
         
     }
     func setChipView(){
@@ -345,7 +359,7 @@ class RequestPlansContentsVC: UIViewController,UIGestureRecognizerDelegate {
 //MARK: Extension
 extension RequestPlansContentsVC: UITextViewDelegate{
     func setPlaceholder() {
-        plansContentsTextView.text = "약속 상세 내용"
+        plansContentsTextView.text = textViewPlaceHolderConstant
         plansContentsTextView.textColor = UIColor.grey04
     }
     
@@ -360,7 +374,7 @@ extension RequestPlansContentsVC: UITextViewDelegate{
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.isEmpty {
-            textView.text = "약속 상세 내용"
+            textView.text = textViewPlaceHolderConstant
             textView.textColor = UIColor.grey04
         }
         plansContentsView.layer.borderWidth = 0
@@ -372,6 +386,8 @@ extension RequestPlansContentsVC: UITextViewDelegate{
         style.lineSpacing = 10
         attrString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSMakeRange(0, attrString.length))
         textView.attributedText = attrString
+        
+        switchNextButtonStatus()//텍스트뷰 텍스트 바뀔 때 활성화할지 판단
     }
 }
 
@@ -471,6 +487,7 @@ extension RequestPlansContentsVC: UITableViewDelegate{
         }
         tableView.isHidden = true
         searchTextField.endEditing(true)
+        
     }
 }
 

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansDateVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansDateVC.swift
@@ -47,10 +47,6 @@ class RequestPlansDateVC: UIViewController {
         $0.text = "약속 신청"
         $0.font = UIFont.hanSansBoldFont(ofSize: 18)
     }
-    private let closeButton = UIButton().then{
-        $0.setBackgroundImage(UIImage(named: "btn_close_bold"), for: .normal)
-        $0.addTarget(self, action: #selector(touchUpCloseButton), for: .touchUpInside)
-    }
     private let addDateView = UIView().then{
         $0.backgroundColor = UIColor.white
     }
@@ -671,11 +667,6 @@ class RequestPlansDateVC: UIViewController {
         navigationController?.popViewController(animated: true)
     }
     
-    @objc func touchUpCloseButton() { //나중에 구현~
-//        self.tabBarController?.tabBar.isHidden = false
-//        navigationController?.popToRootViewController(animated: true)
-    }
-
 
     
 
@@ -691,8 +682,7 @@ class RequestPlansDateVC: UIViewController {
                           ])
         
         titleView.addSubviews([backButton,
-                               titleLabel,
-                               closeButton])
+                               titleLabel])
         
         addDateView.addSubviews([selectedDateView,
                                  addButton])
@@ -744,11 +734,6 @@ class RequestPlansDateVC: UIViewController {
         titleLabel.snp.makeConstraints{
             $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview()
-        }
-        closeButton.snp.makeConstraints{
-            $0.trailing.equalToSuperview().offset(-4)
-            $0.centerY.equalToSuperview()
-            $0.width.height.equalTo(48)
         }
         addDateView.snp.makeConstraints{
             $0.top.equalTo(titleView.snp.bottom)

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansDateVC.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/RequestPlansDateVC.swift
@@ -20,7 +20,8 @@ class RequestPlansDateVC: UIViewController {
     var todayDate = Date()
     var selectedDate = PickedDate()//선택된 날짜 + 시간
     var selectedDay = Date()//선택된 날짜
-    var addedDateList = [PickedDate]()// 선택된 날짜 + 시간 모음
+    // 선택된 날짜 + 시간 모음
+    var addedDateList = [PickedDate]()//안 쓰임
     var defaultStartDate = Date()
     var defaultEndDate = Date()
     var weekCalendarDateList = [Date]()//일곱개 날짜 배열
@@ -248,10 +249,11 @@ class RequestPlansDateVC: UIViewController {
     }
     
     private let requestPlansButton = UIButton().then{
-        $0.backgroundColor = UIColor.pink01
+        $0.backgroundColor = UIColor.grey02
         $0.setTitle("약속 신청", for: .normal)
         $0.titleLabel?.font = UIFont.hanSansMediumFont(ofSize: 16)
         $0.layer.cornerRadius = 10
+        $0.isUserInteractionEnabled = false
         $0.addTarget(self, action: #selector(touchRequestButton(_:)), for: .touchUpInside)
     }
     private let fillView = UIView().then{
@@ -285,38 +287,10 @@ class RequestPlansDateVC: UIViewController {
         requestPlans(guests: guestsToRequest, title: titleToRequest, contents: contentsToRequest, date: date, start: start, end: end)
     }
     
-    private func requestPlans(guests: [[String: Any]],
-                              title: String,
-                              contents: String,
-                              date: [String],
-                              start: [String],
-                              end: [String]
-                              ) {
-        print(guests, title, contents, date, start, end, "gdadfsa")
-        PostRequestPlansService.shared.requestPlans(
-            guests: guests,
-            title: title,
-            contents: contents,
-            date: date,
-            start: start,
-            end: end) { responseData in
-                switch responseData {
-                case .success(_), .pathErr:
-                    let nextStoryboard = UIStoryboard(name: "Tabbar", bundle: nil)
-                    let nextVC = nextStoryboard.instantiateViewController(identifier: "TabbarVC")
-                    self.tabBarController?.tabBar.isHidden = false
-                    self.tabBarController?.selectedIndex = 0
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: "toastMessage"), object: "약속 신청을 완료했어요.")
-                case .requestErr(_):
-                    print("request err")
-                case .networkFail:
-                    print("network err")
-                case .serverErr:
-                    print("server err")
-                }
-            }
-    }
+   
+        
     
+   
     
 //MARK: Func
     func initSelectedDay(){
@@ -333,6 +307,7 @@ class RequestPlansDateVC: UIViewController {
         thuCell.tapCellViewDelegate = self
         friCell.tapCellViewDelegate = self
         satCell.tapCellViewDelegate = self
+        bottomSheetView.pickedDateListDelegate = self
         
     }
     func setCellList() {
@@ -1109,29 +1084,54 @@ extension RequestPlansDateVC: tapCellViewDelegate{
     
 }
 
+extension RequestPlansDateVC: PickedDateListChangedDelegate{
+    func pickedDateListChanged(view: SelectedDateSheet) {
+        if view.pickedDateList.count > 0 {
+            requestPlansButton.backgroundColor = UIColor.pink01
+            requestPlansButton.isUserInteractionEnabled  = true
+        }else{
+            requestPlansButton.backgroundColor = UIColor.grey02
+            requestPlansButton.isUserInteractionEnabled  = false
+        }
+    }
+}
+
 //MARK: Network
 
 extension RequestPlansDateVC{
-//    func requestPlans(){
-//        PostRequestPlansService.shared.requestPlans(guest: <#T##[Host]#>, title: <#T##String#>, contents: <#T##String#>, date: <#T##[String]#>, start: <#T##[String]#>, end: <#T##[String]#>){ responseData in
-//            switch responseData {
-//            case.success(let requestResponse):
-//                guard let response = requestResponse as? PlanRequestData else { return }
-//                if let plansData = response.data{
-//                    //노티피케이션 센터 이용해서 팝시키고 메인에 토스트 띄우기
-//                }
-//            case .requestErr(let msg):
-//                print("requestERR \(msg)")
-//            case .pathErr:
-//                print("pathErr")
-//            case .serverErr:
-//                print("serverErr")
-//            case .networkFail:
-//                print("networkFail")
-//
-//            }
-//        }
-//    }
+    
+    private func requestPlans(guests: [[String: Any]],
+                              title: String,
+                              contents: String,
+                              date: [String],
+                              start: [String],
+                              end: [String]
+                              ) {
+        print(guests, title, contents, date, start, end, "gdadfsa")
+        PostRequestPlansService.shared.requestPlans(
+            guests: guests,
+            title: title,
+            contents: contents,
+            date: date,
+            start: start,
+            end: end) { responseData in
+                switch responseData {
+                case .success(_), .pathErr:
+                    let nextStoryboard = UIStoryboard(name: "Tabbar", bundle: nil)
+                    let nextVC = nextStoryboard.instantiateViewController(identifier: "TabbarVC")
+                    self.tabBarController?.tabBar.isHidden = false
+                    self.tabBarController?.selectedIndex = 0
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: "toastMessage"), object: "약속 신청을 완료했어요.")
+                case .requestErr(_):
+                    print("request err")
+                case .networkFail:
+                    print("network err")
+                case .serverErr:
+                    print("server err")
+                }
+            }
+    }
+    
 
     func requestCalendarData(year: String, month: String) {
         GetScheduleService.shared.getScheduleData(year: year, month: month)  { responseData in

--- a/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/SelectedDateSheet.swift
+++ b/SeeMeet/SeeMeet/Source/Views/VCs/RequestScene/SelectedDateSheet.swift
@@ -10,6 +10,9 @@ fileprivate let widthRatio = userWidth / 375
 protocol TapTouchAreaViewDelegate{
     func tapTouchAreaView(dateSheetView: SelectedDateSheet)
 }
+protocol PickedDateListChangedDelegate{
+    func pickedDateListChanged(view: SelectedDateSheet)
+}
 class SelectedDateSheet: UIView {
     
     // MARK: - properties
@@ -17,6 +20,9 @@ class SelectedDateSheet: UIView {
     static let identifier: String = "SelectedDateSheet"
     
     var pickedDateList: [PickedDate] = [] {
+        didSet{
+            pickedDateListDelegate?.pickedDateListChanged(view: self)
+        }
         willSet {
             dateTicketsStackView.removeAllSubViews()
             newValue.forEach {
@@ -34,6 +40,7 @@ class SelectedDateSheet: UIView {
     }
     
     var tapTouchAreaViewDelegate: TapTouchAreaViewDelegate?
+    var pickedDateListDelegate: PickedDateListChangedDelegate?
     
     private let grabber: UIView = UIView().then {
         $0.backgroundColor = UIColor.grey02


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
해당 pull request merge와 함께 이슈를 닫으려면 
closed: #Issue_number를 적어주세요 -->
  closed #75 

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
- [x] 약속 신청 뷰에서 내용 작성 후 빈 화면 터치해서 키보드 내려가도록 하기
- [x] 약속신청 첫번째 화면 x버튼 이미지 바꾸고  두번째화면 x버튼 빼버리기
- [x] 약속신청 내용 작성 되어야 다음 버튼 활성화
- [x] bottom sheet view 에 날짜가 선택한게 1개이상 되어야 약속신청 버튼 활성화

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
선택된 시간들 리스트인 pickedDateList 를  VC가 아닌 bottomsheetview 가 가지고 있어서 delegate를 이용하여 VC에 전달 하였습니다.
didset을 이용하여 PickedDateList가 변경 될 때마다 requestPlansButton 의 Status를 결정하는 함수가 호출 되도록 구현하였습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📌 구동 영상
<!-- 구동되는 영상/움짤/캡쳐 등 리뷰어들이 참고할 수 있는 파일을 업로드 해주세요.-->

https://user-images.githubusercontent.com/51031771/151962147-e2aad18c-e9bc-4576-a3da-6131a53130f9.mov


